### PR TITLE
better grep'ing of service names

### DIFF
--- a/scripts/cf-ssh
+++ b/scripts/cf-ssh
@@ -50,7 +50,7 @@ DELIM
     echo "  path: ${app_path}" >> ${manifest}
   fi
 
-  services_bound_to_app=$(cf s | grep " $appname " | awk '{ print $1 }')
+  services_bound_to_app=$(cf s | grep -v 'Getting services in org' | grep "[, ]$appname[, ]" | awk '{ print $1 }')
   if [[ "${services_bound_to_app}X" != "X" ]]; then
     echo "  services:" >> ${manifest}
     for service in ${services_bound_to_app[@]}; do


### PR DESCRIPTION
I had problems with cf-ssh not working because my org had the same name as the app. Also, grep'ing for commas or spaces around the app name should reduce false positives.

Great utility though!
