### PR TITLE
add CF_SSH_TIMEOUT variable to cf-ssh and set it to 10 seconds

### DIFF
--- a/scripts/cf-ssh
+++ b/scripts/cf-ssh
@@ -65,7 +65,11 @@ DELIM
 
   if [[ "$(cf env $appname | grep "^\w\w*: \w\w*")X" != "X" ]]; then
     echo "  env:" >> ${manifest}
-    cf env $appname | grep "^\w\w*: \w\w*" | xargs -L 1 -J % echo "   " % >> ${manifest}
+    if [`uname` == 'Darwin']; then
+        cf env $appname | grep "^\w\w*: \w\w*" | xargs -L 1 -J % echo "   " % >> ${manifest}
+    else
+        cf env $appname | grep "^\w\w*: \w\w*" | xargs -L 1 -I % echo "   " % >> ${manifest}
+    fi
   fi
 }
 

--- a/scripts/cf-ssh
+++ b/scripts/cf-ssh
@@ -30,6 +30,11 @@ done
 # application source code/buildpack next time.
 CF_SSH_CLEANUP=${CF_SSH_CLEANUP:-"delete"}
 
+# $CF_SSH_TIMEOUT should be set to whatever length in seconds
+# you need for your app to have started and tmate to have written
+# out to the log files, for cf-ssh to grep it back out.
+CF_SSH_TIMEOUT=${CF_SSH_TIMEOUT:-"10"}
+
 ssh_appname="$appname-ssh"
 
 manifest=${manifest:-./cf-ssh.yml}
@@ -79,7 +84,7 @@ else
   cf push ${ssh_appname} -f ${manifest}
 fi
 
-sleep 1 # ensure tmate connection setup
+sleep $CF_SSH_TIMEOUT # ensure tmate connection setup
 ssh_host=$(cf logs $ssh_appname --recent | grep tmate.io | tail -n1 | awk '{print $NF }')
 
 if [[ "${ssh_host}X" != "X" ]]; then


### PR DESCRIPTION
This is due to cf-ssh not waiting long enough before grepping logs, deciding that tmate wasn't going to start up and then stopping/deleting the cf app.
